### PR TITLE
デプロイエラーの解消4

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "directories": {
     "lib": "lib"
   },
-  "devDependencies": {
-    "daisyui": "^4.6.0",
-    "postcss": "^8.4.33"
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "esbuild app/javascript/*.js --bundle --sourcemap --outdir=app/assets/builds --public-path=assets",
+    "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/tailwind.css --minify"
   },
   "repository": {
     "type": "git",
@@ -20,5 +21,12 @@
   "bugs": {
     "url": "https://github.com/asaduke/LivePlanningManager/issues"
   },
-  "homepage": "https://github.com/asaduke/LivePlanningManager#readme"
+  "homepage": "https://github.com/asaduke/LivePlanningManager#readme",
+  "dependencies": {
+    "@hotwired/turbo-rails": "^7.3.0",
+    "esbuild": "^0.19.11",
+    "esbuild-rails": "^1.0.7",
+    "daisyui": "^4.6.0",
+    "postcss": "^8.4.33"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,24 @@
 # yarn lockfile v1
 
 
+"@hotwired/turbo-rails@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.3.0.tgz#422c21752509f3edcd6c7b2725bbe9e157815f51"
+  integrity sha512-fvhO64vp/a2UVQ3jue9WTc2JisMv9XilIC7ViZmXAREVwiQ2S4UC7Go8f9A1j4Xu7DBI6SbFdqILk5ImqVoqyA==
+  dependencies:
+    "@hotwired/turbo" "^7.3.0"
+    "@rails/actioncable" "^7.0"
+
+"@hotwired/turbo@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.3.0.tgz#2226000fff1aabda9fd9587474565c9929dbf15d"
+  integrity sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==
+
+"@rails/actioncable@^7.0":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.1.3.tgz#4db480347775aeecd4dde2405659eef74a458881"
+  integrity sha512-ojNvnoZtPN0pYvVFtlO7dyEN9Oml1B6IDM+whGKVak69MMYW99lC2NOWXWeE3bmwEydbP/nn6ERcpfjHVjYQjA==
+
 camelcase-css@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"


### PR DESCRIPTION
## 概要
デプロイに失敗したため、再度試みます。

## 詳細
・[18bb7dc](https://github.com/asaduke/LivePlanningManager/pull/51/commits/18bb7dc48384f6de8ca0ad29a75811874944a3f0)：前回のデプロイエラーは「`build`が見つからない」というものになってしまったため、`package.json`の中身を元に戻し、`devDependencies`に記述していた`daisyui`と`postcss`を`dependencies`に移動させました。