### PR TITLE
デプロイエラーの解消5

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link_tree ../builds
-//= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js


### PR DESCRIPTION
## 概要
デプロイに失敗したため、再度試みます。

## 詳細
・[1502aec](https://github.com/asaduke/LivePlanningManager/pull/53/commits/1502aec52ab18d4bf3fea568e825edd267c59cb5)：`//= link_tree ../../jacascript .js`がエラーの元だったため、削除しました。