### PR TITLE
Fix: Content missingエラーの解消

### DIFF
--- a/app/controllers/packing_items_controller.rb
+++ b/app/controllers/packing_items_controller.rb
@@ -40,6 +40,7 @@ class PackingItemsController < ApplicationController
 
   def toggle
     @packing_item = PackingItem.find(params[:id])
+    @live = @packing_item.live
     @packing_item.update(is_checked: !@packing_item.is_checked)
 
     respond_to do |format|


### PR DESCRIPTION
## 概要
持ち物リストのチェックボックスをクリックした時に「Content missing」と出てしまうエラーを修正しました。